### PR TITLE
Add conditional to show availability of of book when checked out.

### DIFF
--- a/apps/frontend/assets/js/components/SearchResult/index.js
+++ b/apps/frontend/assets/js/components/SearchResult/index.js
@@ -113,7 +113,10 @@ class SearchResult extends Component {
                         </span>
 
                         <span>{data.is_part_of}</span>
-                        { data.call_number && <span className="callNumber">Available in the book stacks {data.call_number}</span> }
+                        
+                        { data.call_number && data.availability_status == "available" && <span className="callNumber">Available in the book stacks {data.call_number}</span> }
+                        
+                        { data.call_number && data.availability_status == "unavailable" && <span className="callNumber">Unavailable {data.call_number}</span> }
 
                         {data.description ? <Accordion title="More Info" titleClass={"more-info"}>
                             <div>


### PR DESCRIPTION
In search results, the availability was only being checked by seeing if the resource had a call number. Now the check confirms the existence of a call number (physical item) AND that it has an availability status of "available" or "unavailable". If "unavailable" a new message displaying saying the book is not available.